### PR TITLE
Fix: "C++" in the name breaks nanoc

### DIFF
--- a/content/talks/2015-10-22 - Cpp14.md
+++ b/content/talks/2015-10-22 - Cpp14.md
@@ -1,5 +1,5 @@
 ---
-title: C++14
+title: Cpp14
 kind: :talk
 date: 2015-10-22
 created_at: 2015-10-03


### PR DESCRIPTION
Fixes breakage with "C++" in the filename/title of a talk.
