### PR TITLE
Update ruby dependency name in default.nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -5,7 +5,7 @@
 let
   env = with pkgs; [
     bundler
-    ruby_2_2_0
+    ruby_2_2
   ];
 in
 


### PR DESCRIPTION
Just for my local setup, does not alter any functionality of the site.
