### PR TITLE
Add prefix to webpage title

### DIFF
--- a/layouts/default.html
+++ b/layouts/default.html
@@ -2,7 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="utf-8">
-        <title><%= @item[:title] %></title>
+        <title>UnFUG - <%= @item[:title] %></title>
         <link rel="stylesheet" href="/stylesheet.css">
         <link rel="alternate" type="application/rss+xml" title="RSS" href="/atom/index.html">
         <meta name="viewport" content="initial-scale=1, maximum-scale=1">


### PR DESCRIPTION
The title should contain not only the item's title but also a part
global for the webpage.