### PR TITLE
Fix table formatting

### DIFF
--- a/content/stylesheet.css
+++ b/content/stylesheet.css
@@ -22,6 +22,10 @@ body {
     font-family: "Open Sans", sans-serif;
 }
 
+table {
+    width: 100%;
+}
+
 a {
     text-decoration: none;
 }


### PR DESCRIPTION
Apparently tables do not always expand to the page width.

Suggested-by: Manuel Messner <mm@skelett.io>