### PR TITLE
Fix identifier creation in some helpers

### DIFF
--- a/lib/ical_helpers.rb
+++ b/lib/ical_helpers.rb
@@ -26,7 +26,7 @@ def generate_ical_items cfg
     ical.add_event generate_event(item, cfg)
   end
 
-  @items.create(ical.to_ical, {:kind => :ical}, "/ical/")
+  @items.create(ical.to_ical, {:kind => :ical}, "/ical")
 end
 
 def generate_ical_items_latest cfg
@@ -38,6 +38,6 @@ def generate_ical_items_latest cfg
     ical.add_event generate_event(item, cfg)
   end
 
-  @items.create(ical.to_ical, {:kind => :ical}, "/ical-latest/")
+  @items.create(ical.to_ical, {:kind => :ical}, "/ical-latest")
 end
 

--- a/lib/tag_helpers.rb
+++ b/lib/tag_helpers.rb
@@ -12,7 +12,7 @@ end
 #
 def generate_tag_pages
   all_tags(items).each do |tag|
-    items.create("", { :tag => tag }, "/tags/#{tag}/")
+    items.create("", { :tag => tag }, "/tags/#{tag}")
   end
 end
 


### PR DESCRIPTION
Apparently the identifiers interface changed in the past. Trailing
slashes in identifiers result in page compilation errors. On the other
hand they are (no longer?) required.

This patch fixes some compilation errors observed by removing trailing
slashes.